### PR TITLE
Search in BSD-style terminfo databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+/test/mirror
+/test/terminfo
+/test/stressTestTerms.txt
+
 # Compiled Object files
 *.slo
 *.lo

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ int main()
 
 	if (result) {
 		auto name = parser.getTermName();
-		auto b    = parser.getCapablity(bin::has_meta_key);
-		auto n    = parser.getCapablity(num::columns);
-		auto s    = parser.getCapablity(str::enter_bold_mode);
+		auto b    = parser.getCapability(bin::has_meta_key);
+		auto n    = parser.getCapability(num::columns);
+		auto s    = parser.getCapability(str::enter_bold_mode);
 
 		std::cout << "\n"
 		          << "Name: " << name << "\n"

--- a/docs/info.md
+++ b/docs/info.md
@@ -74,16 +74,16 @@ int main()
 
 	// Well boolean capablities can return false so
 	// b will be false if capablity is missing
-	auto b = parser.getCapablity(bin::has_meta_key);
+	auto b = parser.getCapability(bin::has_meta_key);
 
 	// Similarly string capablities can return empty strings
 	// in case said capablity is not found for given terminal
-	auto s = parser.getCapablity(str::enter_bold_mode);
+	auto s = parser.getCapability(str::enter_bold_mode);
 
 	// The case becomes tricky when dealing with numerical
 	// capablities. To ease out development, a special var
 	// tdb::NP is provided which denotes NOT PRESENT
-	auto n = parser.getCapablity(num::columns);
+	auto n = parser.getCapability(num::columns);
 	if( n == tdb::NP){
 		// it ain't there
 	}

--- a/include/termdb.hpp
+++ b/include/termdb.hpp
@@ -560,19 +560,19 @@ public:
 		return loadDB(_name, _path);
 	}
 
-	bool getCapablity(tdb::bin _b) const noexcept
+	bool getCapability(tdb::bin _b) const noexcept
 	{
 		const auto b = static_cast<int>(_b);
 		return booleans[b];
 	}
 
-	uint16_t getCapablity(tdb::num _n) const noexcept
+	uint16_t getCapability(tdb::num _n) const noexcept
 	{
 		const auto n = static_cast<int>(_n);
 		return numbers[n];
 	}
 
-	std::string getCapablity(tdb::str _s) const
+	std::string getCapability(tdb::str _s) const
 	{
 		const size_t s = static_cast<int>(_s);
 		std::string result;

--- a/include/termdb.hpp
+++ b/include/termdb.hpp
@@ -586,6 +586,13 @@ public:
 	}
 };
 
+inline char hashCharacter(unsigned char c) {
+	if (c < 10) {
+		return c + '0';
+	} else {
+		return (c - 10) + 'a';
+	}
+}
 
 inline bool TermDb::loadDB(const std::string &_name, std::string _path)
 {
@@ -594,11 +601,26 @@ inline bool TermDb::loadDB(const std::string &_name, std::string _path)
 		return false;
 	}
 
-	_path.append(_name, 0, 1).append(1, '/').append(_name);
-	std::ifstream db(_path.c_str(), std::ios::binary | std::ios::ate);
+	std::string letterPath = _path;
+	letterPath.append(_name, 0, 1).append(1, '/').append(_name);
+	std::ifstream db(letterPath.c_str(), std::ios::binary | std::ios::ate);
 	if (!db) {
-		status = -2;
-		return false;
+		// try using hash value
+		char hash[2];
+		unsigned char firstchar = _name[0];
+		hash[0] = hashCharacter((firstchar & 0xF0) >> 4);
+		hash[1] = hashCharacter(firstchar & 0x0F);
+
+		std::string hashPath = _path;
+		hashPath.append(std::string(&hash[0], 2)).append(1, '/').append(_name);
+
+		db.clear();
+		db.open(hashPath, std::ios::binary | std::ios::ate);
+
+		if (!db) {
+			status = -2;
+			return false;
+		}
 	}
 
 	const int size = db.tellg();

--- a/test/stressTest.cpp
+++ b/test/stressTest.cpp
@@ -25,19 +25,19 @@ int main()
 		std::string termName(parser.getTermName());
 
 		for (auto i = 0; i < tdb::numCapBool; ++i) {
-			const auto b = parser.getCapablity(static_cast<bin>(i));
+			const auto b = parser.getCapability(static_cast<bin>(i));
 			output << b << " ";
 		}
 		output << "\n";
 
 		for (auto i = 0; i < tdb::numCapNum; ++i) {
-			const auto n = parser.getCapablity(static_cast<num>(i));
+			const auto n = parser.getCapability(static_cast<num>(i));
 			output << n << " ";
 		}
 		output << "\n";
 
 		for (auto i = 0; i < tdb::numCapStr; ++i) {
-			const auto s = parser.getCapablity(static_cast<str>(i));
+			const auto s = parser.getCapability(static_cast<str>(i));
 			output << s << " ";
 		}
 		output << "\n\n";

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -125,7 +125,7 @@ TEST(Capablities, Booleans)
 
 	for (auto i = 0; i < 44; ++i) {
 		auto currCap = static_cast<bin>(i);
-		arr[i]       = parser.getCapablity(currCap);
+		arr[i]       = parser.getCapability(currCap);
 	}
 
 	auto revString = "00000010000000000000000000000000000000000010";
@@ -146,7 +146,7 @@ TEST(Capablities, Numbers)
 
 	for (auto i = 0; i < 39; ++i) {
 		auto currCap  = static_cast<num>(i);
-		parsedNums[i] = parser.getCapablity(currCap);
+		parsedNums[i] = parser.getCapability(currCap);
 	}
 
 	ASSERT_EQ(hardNums.size(), parsedNums.size())


### PR DESCRIPTION
On certain platforms, the terminfo database doesn't use the ASCII first character for the lookup, but instead the hexadecimal representation of its ordinal number.

This checks first for the ASCII character (as it originally did) and then for the hex-version if the ASCII lookup fails.